### PR TITLE
don't remove Env prereq

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -23,7 +23,6 @@ remove = constant
 remove = Exporter
 remove = Getopt::Std
 remove = File::Spec
-remove = Env
 
 [Author::Plicease::Upload]
 cpan = 1


### PR DESCRIPTION
results in test failures on system perls that don't install Env (and
other standard modules) by default

resolves #13