### PR TITLE
Add OO interface

### DIFF
--- a/lib/File/Which.pm
+++ b/lib/File/Which.pm
@@ -107,12 +107,12 @@ sub _is_win { my $osname = &_get_osname; ($osname eq 'MSWin32' or $osname eq 'do
 sub _is_dos { _is_win(@_); }
 sub _is_cyg { my $osname = &_get_osname; ($osname eq 'cygwin' || $osname eq 'msys'); }
 
-sub _default_IMPLICIT_CURRENT_DIR {
+sub _default_implicit_current_dir {
   my $self = shift;
   $self->_is_win || $self->_is_vms || $self->_is_mac;
 }
 our $IMPLICIT_CURRENT_DIR = do {
-  File::Which->new->_default_IMPLICIT_CURRENT_DIR;
+  File::Which->new->_default_implicit_current_dir;
 };
 
 sub new {
@@ -124,10 +124,10 @@ sub new {
     osname => $osname,
   }, $class;
 
-  $self->{IMPLICIT_CURRENT_DIR} =
-    exists $opts{IMPLICIT_CURRENT_DIR}
-    ? $opts{IMPLICIT_CURRENT_DIR}
-    : $self->_default_IMPLICIT_CURRENT_DIR;
+  $self->{implicit_current_dir} =
+    exists $opts{implicit_current_dir}
+    ? $opts{implicit_current_dir}
+    : $self->_default_implicit_current_dir;
 
   $self->{PATHEXT} = $self->_default_pathext;
 
@@ -209,7 +209,7 @@ sub which {
     ? File::Which->new(
         # Use global to retain compatibility, but only for the functional
         # interface.
-        IMPLICIT_CURRENT_DIR => $IMPLICIT_CURRENT_DIR,
+        implicit_current_dir => $IMPLICIT_CURRENT_DIR,
       )
     : shift;
   my ($exec) = @_;
@@ -254,7 +254,7 @@ sub which {
     ? @{ $self->{fixed_paths} }
     : @{ $self->_default_path };
 
-  if ( $self->{IMPLICIT_CURRENT_DIR} ) {
+  if ( $self->{implicit_current_dir} ) {
     unshift @path, File::Spec->curdir;
   }
 

--- a/lib/File/Which.pm
+++ b/lib/File/Which.pm
@@ -131,6 +131,10 @@ sub new {
 
   $self->{PATHEXT} = $self->_default_pathext;
 
+  if( exists $opts{fixed_paths} ) {
+    $self->{fixed_paths} = $opts{fixed_paths};
+  }
+
   $self;
 }
 
@@ -246,7 +250,9 @@ sub which {
   return $exec  ## no critic (ValuesAndExpressions::ProhibitMixedBooleanOperators)
           if !$self->_is_vms and !$self->_is_mac and !$self->_is_win and $exec =~ /\// and -f $exec and -x $exec;
 
-  my @path = @{ $self->_default_path };
+  my @path = exists $self->{fixed_paths}
+    ? @{ $self->{fixed_paths} }
+    : @{ $self->_default_path };
 
   if ( $self->{IMPLICIT_CURRENT_DIR} ) {
     unshift @path, File::Spec->curdir;

--- a/t/file_which.t
+++ b/t/file_which.t
@@ -5,7 +5,7 @@ use Test::More tests => 19;
 use File::Spec ();
 use File::Which qw(which where);
 
-unless (File::Which::IS_VMS or File::Which::IS_MAC or File::Which::IS_WIN ) {
+unless (File::Which::IS_VMS() or File::Which::IS_MAC() or File::Which::IS_WIN() ) {
   foreach my $path (qw(
                     corpus/test-bin-unix/test3
                     corpus/test-bin-unix/all
@@ -35,24 +35,24 @@ unless (File::Which::IS_VMS or File::Which::IS_MAC or File::Which::IS_WIN ) {
   );
 
   # Where is the test application
-  my $test_bin = File::Spec->catdir( 'corpus', File::Which::IS_WIN ? 'test-bin-win' : 'test-bin-unix' );
+  my $test_bin = File::Spec->catdir( 'corpus', File::Which::IS_WIN() ? 'test-bin-win' : 'test-bin-unix' );
   ok( -d $test_bin, 'Found test-bin' );
 
   # Set up for running the test application
   @PATH = $test_bin;
-  push @PATH, File::Spec->catdir( 'corpus', 'test-bin-win' ) if File::Which::IS_CYG;
+  push @PATH, File::Spec->catdir( 'corpus', 'test-bin-win' ) if File::Which::IS_CYG();
 
   SKIP: {
-    skip("Not on DOS-like filesystem", 3) unless File::Which::IS_WIN;
+    skip("Not on DOS-like filesystem", 3) unless File::Which::IS_WIN();
     is( lc scalar which('test1'), 'corpus\test-bin-win\test1.exe', 'Looking for test1.exe' );
     is( lc scalar which('test2'), 'corpus\test-bin-win\test2.bat', 'Looking for test2.bat' );
     is( scalar which('test3'), undef, 'test3 returns undef' );
   }
 
   SKIP: {
-    skip("Not on a UNIX filesystem", 1) if File::Which::IS_WIN;
-    skip("Not on a UNIX filesystem", 1) if File::Which::IS_MAC;
-    skip("Not on a UNIX filesystem", 1) if File::Which::IS_VMS;
+    skip("Not on a UNIX filesystem", 1) if File::Which::IS_WIN();
+    skip("Not on a UNIX filesystem", 1) if File::Which::IS_MAC();
+    skip("Not on a UNIX filesystem", 1) if File::Which::IS_VMS();
     is(
       scalar(which('test3')),
       File::Spec->catfile( $test_bin, 'test3'),
@@ -61,7 +61,7 @@ unless (File::Which::IS_VMS or File::Which::IS_MAC or File::Which::IS_WIN ) {
   }
 
   SKIP: {
-    skip("Not on a cygwin filesystem", 2) unless File::Which::IS_CYG;
+    skip("Not on a cygwin filesystem", 2) unless File::Which::IS_CYG();
 
     # Cygwin: should make test1.exe transparent
     is(
@@ -78,7 +78,7 @@ unless (File::Which::IS_VMS or File::Which::IS_MAC or File::Which::IS_WIN ) {
 
   # Make sure that .\ stuff works on DOSish, VMS, MacOS (. is in PATH implicitly).
   SKIP: {
-    unless ( File::Which::IS_WIN or File::Which::IS_VMS ) {
+    unless ( File::Which::IS_WIN() or File::Which::IS_VMS() ) {
       skip("Not on a DOS or VMS filesystem", 1);
     }
 

--- a/t/file_which.t
+++ b/t/file_which.t
@@ -5,7 +5,7 @@ use Test::More tests => 19;
 use File::Spec ();
 use File::Which qw(which where);
 
-unless (File::Which::IS_VMS() or File::Which::IS_MAC() or File::Which::IS_WIN() ) {
+unless (File::Which::_is_vms() or File::Which::_is_mac() or File::Which::_is_win() ) {
   foreach my $path (qw(
                     corpus/test-bin-unix/test3
                     corpus/test-bin-unix/all
@@ -35,24 +35,24 @@ unless (File::Which::IS_VMS() or File::Which::IS_MAC() or File::Which::IS_WIN() 
   );
 
   # Where is the test application
-  my $test_bin = File::Spec->catdir( 'corpus', File::Which::IS_WIN() ? 'test-bin-win' : 'test-bin-unix' );
+  my $test_bin = File::Spec->catdir( 'corpus', File::Which::_is_win() ? 'test-bin-win' : 'test-bin-unix' );
   ok( -d $test_bin, 'Found test-bin' );
 
   # Set up for running the test application
   @PATH = $test_bin;
-  push @PATH, File::Spec->catdir( 'corpus', 'test-bin-win' ) if File::Which::IS_CYG();
+  push @PATH, File::Spec->catdir( 'corpus', 'test-bin-win' ) if File::Which::_is_cyg();
 
   SKIP: {
-    skip("Not on DOS-like filesystem", 3) unless File::Which::IS_WIN();
+    skip("Not on DOS-like filesystem", 3) unless File::Which::_is_win();
     is( lc scalar which('test1'), 'corpus\test-bin-win\test1.exe', 'Looking for test1.exe' );
     is( lc scalar which('test2'), 'corpus\test-bin-win\test2.bat', 'Looking for test2.bat' );
     is( scalar which('test3'), undef, 'test3 returns undef' );
   }
 
   SKIP: {
-    skip("Not on a UNIX filesystem", 1) if File::Which::IS_WIN();
-    skip("Not on a UNIX filesystem", 1) if File::Which::IS_MAC();
-    skip("Not on a UNIX filesystem", 1) if File::Which::IS_VMS();
+    skip("Not on a UNIX filesystem", 1) if File::Which::_is_win();
+    skip("Not on a UNIX filesystem", 1) if File::Which::_is_mac();
+    skip("Not on a UNIX filesystem", 1) if File::Which::_is_vms();
     is(
       scalar(which('test3')),
       File::Spec->catfile( $test_bin, 'test3'),
@@ -61,7 +61,7 @@ unless (File::Which::IS_VMS() or File::Which::IS_MAC() or File::Which::IS_WIN() 
   }
 
   SKIP: {
-    skip("Not on a cygwin filesystem", 2) unless File::Which::IS_CYG();
+    skip("Not on a cygwin filesystem", 2) unless File::Which::_is_cyg();
 
     # Cygwin: should make test1.exe transparent
     is(
@@ -78,7 +78,7 @@ unless (File::Which::IS_VMS() or File::Which::IS_MAC() or File::Which::IS_WIN() 
 
   # Make sure that .\ stuff works on DOSish, VMS, MacOS (. is in PATH implicitly).
   SKIP: {
-    unless ( File::Which::IS_WIN() or File::Which::IS_VMS() ) {
+    unless ( File::Which::_is_win() or File::Which::_is_vms() ) {
       skip("Not on a DOS or VMS filesystem", 1);
     }
 


### PR DESCRIPTION
DRAFT: Start of OO interface.

This PR is just a placeholder. It still needs improvements to the tests, adding
the `os_shell` option (tentative name), documentation, and setting the
`PATH`/`PATHEXT` as options.

Connects to <https://github.com/uperl/File-Which/issues/40>.
